### PR TITLE
Memory / free memory is displayed correctly now

### DIFF
--- a/libraries/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/queries/MemoryQuery.java
+++ b/libraries/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/queries/MemoryQuery.java
@@ -33,7 +33,7 @@ import de.eidottermihi.rpicheck.ssh.impl.RaspiQueryException;
 
 public class MemoryQuery extends GenericQuery<RaspiMemoryBean> {
 
-    private static final String MEMORY_INFO_CMD = "free | sed -n 2,3p | tr -d '\\n' | sed 's/[[:space:]]\\+/,/g'";
+    private static final String MEMORY_INFO_CMD = "free | sed -n 2,2p | tr -d '\\n' | sed 's/[[:space:]]\\+/,/g'";
     private static final Logger LOGGER = LoggerFactory.getLogger(MemoryQuery.class);
 
     public MemoryQuery(SSHClient sshClient) {
@@ -58,7 +58,7 @@ public class MemoryQuery extends GenericQuery<RaspiMemoryBean> {
         final String[] split = output.split(",");
         if (split.length >= 3) {
             final long total = Long.parseLong(split[1]);
-            final long used = Long.parseLong(split[8]);
+            final long used = Long.parseLong(split[2]);
             return new RaspiMemoryBean(total, used);
         } else {
             LOGGER.error("Expected a different output of command: {}",


### PR DESCRIPTION
I removed swap from the output of `free` command and changed two lines to display the right results. There were no memory information at my device before. It's an universal solution.