### PR TITLE
Get total and used memory with vmstat instead of free

### DIFF
--- a/libraries/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/queries/MemoryQuery.java
+++ b/libraries/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/queries/MemoryQuery.java
@@ -33,7 +33,7 @@ import de.eidottermihi.rpicheck.ssh.impl.RaspiQueryException;
 
 public class MemoryQuery extends GenericQuery<RaspiMemoryBean> {
 
-    private static final String MEMORY_INFO_CMD = "free | sed -n 2,3p | tr -d '\\n' | sed 's/[[:space:]]\\+/,/g'";
+    private static final String MEMORY_INFO_CMD = "vmstat -s | sed -n 1,2p | sed 's/[^0-9]*//g' | tr '\\n' ','";
     private static final Logger LOGGER = LoggerFactory.getLogger(MemoryQuery.class);
 
     public MemoryQuery(SSHClient sshClient) {
@@ -56,9 +56,9 @@ public class MemoryQuery extends GenericQuery<RaspiMemoryBean> {
 
     private RaspiMemoryBean formatMemoryInfo(String output) {
         final String[] split = output.split(",");
-        if (split.length >= 3) {
-            final long total = Long.parseLong(split[1]);
-            final long used = Long.parseLong(split[8]);
+        if (split.length == 2) {
+            final long total = Long.parseLong(split[0]);
+            final long used = Long.parseLong(split[1]);
             return new RaspiMemoryBean(total, used);
         } else {
             LOGGER.error("Expected a different output of command: {}",


### PR DESCRIPTION
On Arch Linux there was a problem with displaying "free memory". I changed a shell command which is getting memory information. Now it's reliable, device independent and universal. `free` output may be different depending its version. `vmstat -s` on the other hand produces always the same output. I've cut everything but total and used memory, formatted with `sed` and replaced new lines with commas with `tr`.