### PR TITLE
Update SSHJ

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
     buildTypes {
         release {
             shrinkResources true
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt')//, 'proguard-project.txt'
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,9 @@ android {
 
     defaultConfig {
         applicationId "de.eidottermihi.raspicheck"
-        minSdkVersion 9
+        minSdkVersion 21
         targetSdkVersion 23
+        multiDexEnabled true
         versionName version
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,14 @@ android {
     buildTypes {
         release {
             shrinkResources true
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt')//, 'proguard-project.txt'
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
+        }
+
+        debug {
+            shrinkResources false
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
         }
     }
 

--- a/app/proguard-project.txt
+++ b/app/proguard-project.txt
@@ -22,30 +22,50 @@
 # Dont obfuscate
 -dontobfuscate
 
+-dontwarn com.google.errorprone.annotations.**
 # Libraries
 # SSHJ
 -keep class net.schmizz.** { *; }
 -keep interface net.schmizz.** { *; }
 -keep class com.jcraft.** { *; }
 -keep interface com.jcraft.** { *; }
+-keep class com.hierynomus.sshj.** { *; }
+-keep interface com.hierynomus.sshj.** { *; }
+-keep class djb.** { *; }
+-keep interface djb.** { *; }
+-keep class net.i2p.** { *; }
+-keep interface net.i2p.** { *; }
 -keep class org.spongycastle.** { *; }
 -keep interface org.spongycastle.** { *; }
+-keep class org.bouncycastle.** { *; }
+-keep interface org.bouncycastle.** { *; }
+-dontwarn org.ietf.**
 # were not using ldap
 -dontwarn org.spongycastle.jce.provider.X509LDAPCertStoreSpi
 -dontwarn org.spongycastle.x509.util.LDAPStoreHelper
+# no GssApi Auth
+-dontwarn javax.security.auth.**
+# no JNDI
+-dontwarn javax.naming.**
 # PrettyTime
 -keep class org.ocpsoft.prettytime.** { *; }
 -keep interface org.ocpsoft.prettytime.** { *; }
 # Logback
 -keep class ch.qos.logback.** { *; }
 -keep interface ch.qos.logback.** { *; }
+-dontwarn java.nio.file.**
 # we're not using remote logging
--dontwarn ch.qos.logback.core.net.*
+-dontwarn ch.qos.logback.core.net.**
 # slf4j
 -keep class org.slf4j.** { *; }
 -keep interface org.slf4j.** { *; }
 # guava
+-dontwarn com.google.j2objc.annotations.**
+-dontwarn com.google.appengine.**
+-dontwarn com.google.apphosting.**
+-dontwarn java.lang.ClassValue
 -dontwarn sun.misc.Unsafe
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 # Submodule Libraries
 -keep class de.eidottermihi.rpicheck.ssh.** { *; }

--- a/ssh/build.gradle
+++ b/ssh/build.gradle
@@ -10,10 +10,15 @@ targetCompatibility = JavaVersion.VERSION_1_7
 
 
 dependencies {
-    compile 'com.google.guava:guava:18.0'
+    compile 'com.google.guava:guava:20.0'
     compile 'org.ocpsoft.prettytime:prettytime:2.1.2.Final'
     compile 'org.slf4j:slf4j-api:1.7.7'
-    compile 'de.eidottermihi:sshj4android:0.11.0'
+    compile 'com.hierynomus:sshj:0.22.0'
+    compile 'com.madgag.spongycastle:core:1.56.0.0'
+    compile 'com.madgag.spongycastle:prov:1.56.0.0'
+    compile 'com.madgag.spongycastle:bcpkix-jdk15on:1.56.0.0'
+    compile 'com.madgag.spongycastle:bcpg-jdk15on:1.56.0.0'
+
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-all:1.9.5'

--- a/ssh/build.gradle
+++ b/ssh/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compile 'com.google.guava:guava:20.0'
     compile 'org.ocpsoft.prettytime:prettytime:2.1.2.Final'
     compile 'org.slf4j:slf4j-api:1.7.7'
-    compile 'com.hierynomus:sshj:0.22.0'
+    compile 'com.hierynomus:sshj:0.23.0'
     compile 'com.madgag.spongycastle:core:1.56.0.0'
     compile 'com.madgag.spongycastle:prov:1.56.0.0'
     compile 'com.madgag.spongycastle:bcpkix-jdk15on:1.56.0.0'

--- a/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/IQueryService.java
+++ b/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/IQueryService.java
@@ -182,8 +182,6 @@ public interface IQueryService {
      */
     public abstract void disconnect() throws RaspiQueryException;
 
-    public abstract String getFile(String path);
-
     public abstract String getHostname();
 
     public abstract void setHostname(String hostname);

--- a/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/RaspiQuery.java
+++ b/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/RaspiQuery.java
@@ -31,10 +31,12 @@ import net.schmizz.sshj.transport.TransportException;
 import net.schmizz.sshj.userauth.UserAuthException;
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.security.Security;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -102,6 +104,11 @@ public class RaspiQuery implements IQueryService {
     private String hostname;
     private String username;
     private int port = DEFAULT_SSH_PORT;
+
+    static {
+        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+        Security.addProvider(new org.spongycastle.jce.provider.BouncyCastleProvider());
+    }
 
     /**
      * Initialize a new RaspiQuery.

--- a/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/RaspiQuery.java
+++ b/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/RaspiQuery.java
@@ -36,10 +36,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.security.Provider;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -118,6 +120,18 @@ public class RaspiQuery implements IQueryService {
      * @param port ssh port to use (if null, default will be used)
      */
     public RaspiQuery(final String host, final String user, final Integer port) {
+        final Provider[] providers = Security.getProviders();
+        LOGGER.debug("Registered JCE providers...");
+        for (Provider prov : providers
+                ) {
+            LOGGER.debug("Provider: {} - {}", prov.getName(), prov.getInfo());
+        }
+        final Set<String> signatures = Security.getAlgorithms("signature");
+        LOGGER.debug("Availabe signatures...");
+        for (String sig : signatures
+                ) {
+            LOGGER.debug("Signature: {}", sig);
+        }
         if (Strings.isNullOrEmpty(host)) {
             throw new IllegalArgumentException("hostname should not be blank.");
         } else if (Strings.isNullOrEmpty(user)) {

--- a/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/RaspiQuery.java
+++ b/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/RaspiQuery.java
@@ -22,7 +22,6 @@ import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 
-import net.schmizz.sshj.AndroidConfig;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.common.IOUtils;
 import net.schmizz.sshj.connection.ConnectionException;
@@ -31,14 +30,11 @@ import net.schmizz.sshj.connection.channel.direct.Session.Command;
 import net.schmizz.sshj.transport.TransportException;
 import net.schmizz.sshj.userauth.UserAuthException;
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
-import net.schmizz.sshj.xfer.FileSystemFile;
-import net.schmizz.sshj.xfer.scp.SCPFileTransfer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.security.Security;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -106,11 +102,6 @@ public class RaspiQuery implements IQueryService {
     private String hostname;
     private String username;
     private int port = DEFAULT_SSH_PORT;
-
-    static {
-        //Security.removeProvider("BC");
-        Security.insertProviderAt(new org.spongycastle.jce.provider.BouncyCastleProvider(), 1);
-    }
 
     /**
      * Initialize a new RaspiQuery.
@@ -1187,28 +1178,6 @@ public class RaspiQuery implements IQueryService {
     /*
      * (non-Javadoc)
      *
-     * @see de.eidottermihi.rpicheck.ssh.IQueryService#getFile(java.lang.String)
-     */
-    @Override
-    public final String getFile(String path) {
-        if (client != null) {
-            if (client.isConnected()) {
-                SCPFileTransfer scpClient = new SCPFileTransfer(client);
-                try {
-                    scpClient.download("/boot/config.txt", new FileSystemFile(
-                            "/"));
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-
-            }
-        }
-        return null;
-    }
-
-    /*
-     * (non-Javadoc)
-     *
      * @see de.eidottermihi.rpicheck.ssh.IQueryService#getHostname()
      */
     @Override
@@ -1274,7 +1243,7 @@ public class RaspiQuery implements IQueryService {
      */
 
     public SSHClient newAndroidSSHClient() {
-        return new SSHClient(new AndroidConfig());
+        return new SSHClient(new SpongyCastleAndroidConfig());
     }
 
     @Override

--- a/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/SpongyCastleAndroidConfig.java
+++ b/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/SpongyCastleAndroidConfig.java
@@ -1,0 +1,19 @@
+package de.eidottermihi.rpicheck.ssh.impl;
+
+import net.schmizz.sshj.AndroidConfig;
+import net.schmizz.sshj.Config;
+import net.schmizz.sshj.common.SecurityUtils;
+import net.schmizz.sshj.transport.random.BouncyCastleRandom;
+import net.schmizz.sshj.transport.random.SingletonRandomFactory;
+
+/**
+ * Created by Michael on 28.08.2017.
+ */
+
+class SpongyCastleAndroidConfig extends AndroidConfig {
+    public SpongyCastleAndroidConfig() {
+        super();
+        initKeyExchangeFactories(true);
+        initFileKeyProviderFactories(true);
+    }
+}

--- a/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/SpongyCastleAndroidConfig.java
+++ b/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/SpongyCastleAndroidConfig.java
@@ -1,16 +1,40 @@
 package de.eidottermihi.rpicheck.ssh.impl;
 
-import net.schmizz.sshj.AndroidConfig;
-import net.schmizz.sshj.Config;
+import com.hierynomus.sshj.signature.SignatureEdDSA;
+
+import net.schmizz.sshj.DefaultConfig;
 import net.schmizz.sshj.common.SecurityUtils;
-import net.schmizz.sshj.transport.random.BouncyCastleRandom;
+import net.schmizz.sshj.signature.SignatureDSA;
+import net.schmizz.sshj.signature.SignatureRSA;
+import net.schmizz.sshj.transport.random.JCERandom;
 import net.schmizz.sshj.transport.random.SingletonRandomFactory;
 
-public class SpongyCastleAndroidConfig extends AndroidConfig {
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import java.security.Security;
+
+public class SpongyCastleAndroidConfig extends DefaultConfig {
+
+    static {
+        SecurityUtils.registerSecurityProvider("org.spongycastle.jce.provider.BouncyCastleProvider");
+    }
+
     public SpongyCastleAndroidConfig() {
         super();
         initKeyExchangeFactories(true);
         initRandomFactory(true);
         initFileKeyProviderFactories(true);
+    }
+
+    // don't add ECDSA
+    protected void initSignatureFactories() {
+        setSignatureFactories(new SignatureRSA.Factory(), new SignatureDSA.Factory(),
+                // but add EdDSA !
+                new SignatureEdDSA.Factory());
+    }
+
+    @Override
+    protected void initRandomFactory(boolean ignored) {
+        setRandomFactory(new SingletonRandomFactory(new JCERandom.Factory()));
     }
 }

--- a/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/SpongyCastleAndroidConfig.java
+++ b/ssh/src/main/java/de/eidottermihi/rpicheck/ssh/impl/SpongyCastleAndroidConfig.java
@@ -6,14 +6,11 @@ import net.schmizz.sshj.common.SecurityUtils;
 import net.schmizz.sshj.transport.random.BouncyCastleRandom;
 import net.schmizz.sshj.transport.random.SingletonRandomFactory;
 
-/**
- * Created by Michael on 28.08.2017.
- */
-
-class SpongyCastleAndroidConfig extends AndroidConfig {
+public class SpongyCastleAndroidConfig extends AndroidConfig {
     public SpongyCastleAndroidConfig() {
         super();
         initKeyExchangeFactories(true);
+        initRandomFactory(true);
         initFileKeyProviderFactories(true);
     }
 }


### PR DESCRIPTION
Using latest version of SSHJ with customized AndroidConfig.

Adds support for ed25519 keys (fix #154 ). Only works tough when the public key is located in the same folder as the private key and the filename is <privatekey-file-name>.pub

Also adds support for stronger encryption (fix #125) because latest SpongyCastle is now included.