### PR TITLE
Update sshj version to 0.29.0

### DIFF
--- a/ssh/build.gradle
+++ b/ssh/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compile "com.madgag.spongycastle:bcpkix-jdk15on:1.56.0.0"
     compile "com.madgag.spongycastle:bcpg-jdk15on:1.56.0.0"
 
-    compile "com.hierynomus:sshj:0.26.0"
+    compile "com.hierynomus:sshj:0.29.0"
     compile "org.bouncycastle:bcprov-jdk15on:1.57"
     compile "org.bouncycastle:bcpkix-jdk15on:1.57"
     compile "com.jcraft:jzlib:1.1.3"


### PR DESCRIPTION
Updating sshj to the current release allowed me to authenticate with a private key while I was unable to before.